### PR TITLE
Filter out empty entities internally

### DIFF
--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -344,7 +344,7 @@ async def parse_text_entities(
 
     return {
         "message": text,
-        "entities": entities
+        "entities": list(filter(lambda x:x.length > 0, entities))
     }
 
 


### PR DESCRIPTION
I guess it's fine to handle empty entities internally to avoid ENTITY_BOUNDS_INVALID , so the client won't send the empty entities